### PR TITLE
Update Git-Sync to v4.1.0 to resolve arm64 issue

### DIFF
--- a/pods/sidecar-cloud.yml
+++ b/pods/sidecar-cloud.yml
@@ -12,7 +12,7 @@ spec:
     - name: html
       mountPath: /usr/share/nginx/
   - name: ctr-sync
-    image: k8s.gcr.io/git-sync:v3.1.6
+    image: registry.k8s.io/git-sync/git-sync:v4.1.0
     volumeMounts:
     - name: html
       mountPath: /tmp/git

--- a/pods/sidecar-local.yml
+++ b/pods/sidecar-local.yml
@@ -15,7 +15,7 @@ spec:
     - name: html
       mountPath: /usr/share/nginx/
   - name: ctr-sync
-    image: k8s.gcr.io/git-sync:v3.1.6
+    image: registry.k8s.io/git-sync/git-sync:v4.1.0
     volumeMounts:
     - name: html
       mountPath: /tmp/git


### PR DESCRIPTION
Updating git-sync to registry.k8s.io/git-sync/git-sync:v4.1.0 to resolve an issue with the prior git-sync version not running properly on arm64 architecture.

Git-sync 3.1.6 running against a raspberry pi cluster running k3s would fail. The error was:

$ kubectl logs git-sync -c ctr-sync
INFO: detected pid 1, running init handler
I0106 12:18:03.166056      12 main.go:321]  "level"=0 "msg"="starting up"  "args"=["/git-sync"] "pid"=12
I0106 12:18:03.166221      12 main.go:574]  "level"=0 "msg"="cloning repo"  "origin"="https://github.com/.../ps-sidecar.git" "path"="/tmp/git"
E0106 12:18:03.172930      12 main.go:347]  "msg"="failed to sync repo, aborting" "error"="error running command: fork/exec /usr/bin/git: exec format error: { stdout: \"\", stderr: \"\" }"

This is apparently a common issue with running the wrong architecture.

Despite version 3.1.6 having an arm64 release (https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/git-sync@sha256:aa88eb188b3bd4bdd2a4237a4d7be2b8df0cad5be002ad82c13bf47aa2f9bd13/details?tab=pull), it fails to run properly.

Moving to 4.1.0 has resolved the issue.